### PR TITLE
Implement automatic note location detection and cropping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 sandbox
 *.texpadtmp
 .eggs
+/build

--- a/pdf2keynote/pdf2keynote.py
+++ b/pdf2keynote/pdf2keynote.py
@@ -247,7 +247,7 @@ def pdf_to_keynote(path_to_pdf, path_to_keynote=None):
 
         # TODO select first slide
 
-        save_keynote_document(path_to_keynote)
+    save_keynote_document(path_to_keynote)
 
 
 def main():

--- a/pdf2keynote/pdf2keynote.py
+++ b/pdf2keynote/pdf2keynote.py
@@ -38,6 +38,8 @@ from Quartz import (
     kPDFDisplayBoxCropBox,
 )
 
+Dimensions = tuple[float, float]
+Bounds = tuple[Dimensions, Dimensions]
 
 def escape(notes):
     return '"{}"'.format(notes)

--- a/pdf2keynote/pdf2keynote.py
+++ b/pdf2keynote/pdf2keynote.py
@@ -97,13 +97,22 @@ def do_apple_script(command, *args):
 def lines(selection):
     return [line.string() for line in selection.selectionsByLine() or []]
 
+def has_notes(pdf: PDFDocument) -> bool:
+    """
+     Checks if the PDF is likely to include a note slide. 
+     Only works between 21:18 and 21:9 format slides. So does not work for 1:1 or portait mode slides!
+    """
+    title_page = pdf.pageAtIndex_(0)
+    (x, y), (w, h) = title_page.boundsForBox_(kPDFDisplayBoxMediaBox)
+
+    return w / h > 21/9 # = 7/3 # Usual aspect ratios are 4/3 or 16/9, therefore 2 * 4/3 = 8/3 and 32/9 are the ratios for double-slides.
 
 def get_beamer_notes_for_page(pdf, page_number):
     title_page = pdf.pageAtIndex_(0)
     (x, y), (w, h) = title_page.boundsForBox_(kPDFDisplayBoxMediaBox)
 
     notes = ""
-    if w / h > 7 / 3:  # likely to be a two screens pdf
+    if has_notes(pdf): 
         # heuristic to guess template of note slide
         w /= 2
         title = lines(title_page.selectionForRect_(((x, y), (w, h))))


### PR DESCRIPTION
This PR refactors some of the note related code and generalizes note extraction and cropping. 


It uses the original heuristic that looks for the miniature on the note page. 
If it isn't found on the right, the bounds of the content and the notes get swapped, and we look on the left. 

If the miniature still hasn't been found, we assume that the notes are on the right.

This PR resolves https://github.com/remymuller/pdf2keynote/issues/6